### PR TITLE
Fixed: 'Server error. Please try again' message when registering a user

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -71,9 +71,11 @@ app.post("/api/register", async (req, res) => {
     });
     await newUser.save();
 
-    res
-      .status(201)
-      .json({ success: true, message: "User registered successfully" });
+    res.status(201).json({
+      success: true,
+      message: "User registered successfully",
+      user: { _id: newUser._id, name: newUser.name },
+    });
   } catch (error) {
     res.status(500).json({ success: false, message: "Server error" });
   }


### PR DESCRIPTION
frontend/backend mismatch where the frontend was expecting the _id and name response Updated the app.post the return the newUser._id and newUser.name